### PR TITLE
MIRA-1 Remove .host file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.ko
 *.obj
 *.elf
+*.x
 
 # Linker output
 *.ilk

--- a/.host
+++ b/.host
@@ -1,2 +1,0 @@
-host: aarch64 Linux 6.1.0-rpi7-rpi-v8
-gcc version 12.2.0 (Debian 12.2.0-14) 

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ miralib/menudriver: menudriver.c Makefile
 tellcc:
 	@echo $(CC) $(CFLAGS)
 cleanup:
-#to be done on moving to a new host
 	-rm -rf *.o fdate miralib/menudriver mira$(EX)
 	./unprotect
 	-rm -f miralib/preludx miralib/stdenv.x miralib/ex/*.x #miralib/ex/*/*.x
+.host:
 	./hostinfo > .host
 install:
 	make -s all


### PR DESCRIPTION
Host specific file is removed from repo and it's created, if needed, when the executable is built.